### PR TITLE
debug cc and multitaper

### DIFF
--- a/pyadjoint/adjoint_source_types/multitaper_misfit.py
+++ b/pyadjoint/adjoint_source_types/multitaper_misfit.py
@@ -896,7 +896,7 @@ class MultitaperMisfit:
         # Create transfer function
         trans_func = np.zeros(self.nlen_f, dtype=complex)
         for i in range(nfreq_min, nfreq_max):
-            if abs(bot_tf[i]) < wtr_use:
+            if abs(bot_tf[i]) >= wtr_use:
                 trans_func[i] = top_tf[i] / bot_tf[i]
             else:
                 trans_func[i] = top_tf[i] / (bot_tf[i] + wtr_use)

--- a/pyadjoint/utils/cctm.py
+++ b/pyadjoint/utils/cctm.py
@@ -45,7 +45,7 @@ def calculate_cc_shift(d, s, dt, use_cc_error=True, dt_sigma_min=1.0,
     # Uncertainty estimate based on cross-correlations to be used for norm.
     if use_cc_error:
         sigma_dt, sigma_dlna = calculate_cc_error(d=d, s=s, dt=dt,
-                                                  cc_shift=tshift, dlna=dlna,
+                                                  cc_shift=ishift, dlna=dlna,
                                                   dt_sigma_min=dt_sigma_min,
                                                   dlna_sigma_min=dlna_sigma_min
                                                   )


### PR DESCRIPTION
Hi @bch0w 

I found some potential errors in cross-correlation and multi-taper measurements.

- The `cc_shift` in function `cc_correction` is the time shift in samples. Thus, the input argument `cc_shift` in `calculate_cc_error` should be replaced with `ishift`.
https://github.com/adjtomo/pyadjoint/blob/a892d3a4222891c0ab72ae6a673ead214c6fdce3/pyadjoint/utils/cctm.py#L253-L283

- In the `calculate_multitaper` ,
https://github.com/adjtomo/pyadjoint/blob/a892d3a4222891c0ab72ae6a673ead214c6fdce3/pyadjoint/adjoint_source_types/multitaper_misfit.py#L899-L902
 When the denominator is less than the water level, the water level should be added to the denominator to ensure stable division. Thus, it should be `abs(bot_tf[i]) >= wtr_use`.

Best,
Mijian